### PR TITLE
Small console improvements

### DIFF
--- a/objects/obj_decomp_console/Create_0.gml
+++ b/objects/obj_decomp_console/Create_0.gml
@@ -9,8 +9,10 @@ input_text = "";
 history = array_create(0);
 commands = array_create(0);
 
+// 0 = most recent, len - 1 = least recent
 commands_history = array_create(0);
-commands_history_index = 0;
+commands_history_index = -1;
+commands_textbox = "";
 
 scroll_offset = 0;
 
@@ -47,13 +49,14 @@ function reset_input()
 	input_text = "";
 	command_name = "";
 	scroll_offset = 0;
-	commands_history_index = 0;
+	commands_history_index = -1;
+	commands_textbox = "";
 }
 
 function command_push_history()
 {
-	array_push(commands_history, input_text);
-	if (array_length(commands_history) >= COMMAND_CONSOLE_HISTORY_MAX)
+	array_insert(commands_history, 0, input_text);
+	if (array_length(commands_history) > COMMAND_CONSOLE_HISTORY_MAX)
 		array_pop(commands_history);
 }
 event_user(0);

--- a/objects/obj_decomp_console/Create_0.gml
+++ b/objects/obj_decomp_console/Create_0.gml
@@ -26,6 +26,7 @@ show_collision = false;
 show_position = false;
 
 #macro COMMAND_CONSOLE_HISTORY_MAX 64
+#macro SCROLL_MIN_ENTRIES_SHOWN 6
 function activate() 
 {
 	trace("Activating Console");

--- a/objects/obj_decomp_console/Draw_75.gml
+++ b/objects/obj_decomp_console/Draw_75.gml
@@ -152,6 +152,16 @@ if (command_name != "")
 		draw_set_color(c_red);
 		
 	draw_text(input_text_x + ((string_pos(command_name, input_text) - 1) * char_width), input_text_y, command_name);
+	
+	// Draw inline help text
+	var help_text = getCommandHelpText(command_name);
+	
+	if (help_text != "")
+	{
+		draw_set_color(c_gray);
+		draw_text(input_text_x + string_width(input_text + string_repeat("  ", 3)), input_text_y, help_text);
+	}
+	
 	draw_set_color(c_white);
 }
 

--- a/objects/obj_decomp_console/Draw_75.gml
+++ b/objects/obj_decomp_console/Draw_75.gml
@@ -91,9 +91,9 @@ var history_len = array_length(history);
 var history_max_pixel_height = (COMMAND_CONSOLE_HISTORY_MAX * text_height) - input_box_y
 var history_pixel_height = history_len * text_height;
 
-for (var i = 0; i < history_len; i++)
+for (var i = scroll_offset; i < history_len; i++)
 {
-	draw_text(bounds_rect.x + 2, input_box_y - ((i + 1) * char_height), history[i]);
+	draw_text(bounds_rect.x + 2, input_box_y - ((i - scroll_offset + 1) * char_height), history[i]);
 }
 
 if (history_pixel_height > input_box_y)
@@ -111,11 +111,14 @@ if (history_pixel_height > input_box_y)
 	
 	var normalized_history_height = scroll_height / history_max_pixel_height;
 	
+	var scrollbar_progress = 1 - clamp(scroll_offset / (history_len - SCROLL_MIN_ENTRIES_SHOWN), 0, 1);
+	var scrollbar_ratio = SCROLL_MIN_ENTRIES_SHOWN / history_len;
+	var scrollbar_height = scroll_height * scrollbar_ratio;
 
 	var scrollbar_x = scroll_x;
-	var scrollbar_y = scroll_y + ((history_pixel_height - input_box_y) * normalized_history_height);
+	var scrollbar_y = scroll_y + (scroll_height - scrollbar_height) * scrollbar_progress;
 	var scrollbar_right = scrollbar_x + scroll_width;
-	var scrollbar_bottom = scroll_y + scroll_height;
+	var scrollbar_bottom = scrollbar_y + scrollbar_height;
 	
 	//if (point_in_rectangle(mouse_x - view_get_xport(0), mouse_y - view_get_yport(0), scrollbar_x, scrollbar_y, scrollbar_right, scrollbar_bottom))
 	//	draw_set_color(c_yellow);
@@ -169,22 +172,50 @@ if (command_name != "")
 
 #region Popout
 
-var popout_x = bounds_rect.x;
-var popout_y = bounds_rect.bottom;
-
-/*
-if (valid_command_name)
+if (command_name != "" && !valid_command_name)
 {
+	var matching_cmds = array_create(0);
+	var rect_width = 0;
+	var rect_height = 0;
 	
-}
-else
-{
-	for (var i = 0; i < array_length(commands); i++)
+	for (var i = 0; i < array_length(commands) && array_length(matching_cmds) <= 6; i++)
 	{
-		draw_text(popout_x, popout_y + (i * char_height), commands[i].displayName);
+		if (string_starts_with(commands[i].displayName, command_name))
+		{
+			array_push(matching_cmds, commands[i].displayName);
+			rect_width = max(rect_width, string_width(commands[i].displayName));
+			rect_height += char_height;
+		}
+	}
+	
+	if (array_length(matching_cmds) > 0)
+	{
+		var popout_border = 2;
+		var popout_pad = 2;
+		
+		var popout_x = bounds_rect.x + popout_border;
+		var popout_y = bounds_rect.bottom + char_height + popout_border;
+		var popout_width = popout_x + rect_width + 2 * popout_pad;
+		var popout_height = popout_y + rect_height + 2 * popout_pad;
+
+		var border_x = popout_x - popout_border - popout_pad;
+		var border_y = popout_y - popout_border - popout_pad;
+		var border_right = popout_x + rect_width + popout_border + 2 * popout_pad;
+		var border_bottom = popout_y + rect_height + popout_border + 2 * popout_pad;
+	
+		draw_set_color(c_white);
+		ossafe_fill_rectangle(border_x, border_y, border_right, border_bottom);
+		draw_set_color(c_black);
+		ossafe_fill_rectangle(popout_x, popout_y, popout_width, popout_height);
+		draw_set_color(c_white);
+	
+		for (var i = 0; i < array_length(matching_cmds); i++)
+		{
+			draw_text(popout_x + popout_pad, popout_y + popout_pad + (i * char_height), matching_cmds[i]);
+		}
 	}
 }
-*/
+
 #endregion
 
 #region Room name

--- a/objects/obj_decomp_console/Draw_75.gml
+++ b/objects/obj_decomp_console/Draw_75.gml
@@ -93,7 +93,7 @@ var history_pixel_height = history_len * text_height;
 
 for (var i = 0; i < history_len; i++)
 {
-	draw_text(bounds_rect.x + 2, input_box_y - ((history_len - i) * char_height), history[i]);
+	draw_text(bounds_rect.x + 2, input_box_y - ((i + 1) * char_height), history[i]);
 }
 
 if (history_pixel_height > input_box_y)

--- a/objects/obj_decomp_console/Step_0.gml
+++ b/objects/obj_decomp_console/Step_0.gml
@@ -49,6 +49,18 @@ if (prev_dir_y != dir_y && dir_y != 0)
 	}
 }
 
+if (prev_dir_x != dir_x && dir_x != 0)
+{
+	if (dir_x == 1)
+	{
+		scroll_offset = min(scroll_offset + 1, max(array_length(history) - SCROLL_MIN_ENTRIES_SHOWN, 0));
+	}
+	else if (dir_x == -1)
+	{
+		scroll_offset = max(scroll_offset - 1, 0);
+	}
+}
+
 input_text = keyboard_string;
 
 command_name = "";

--- a/objects/obj_decomp_console/Step_0.gml
+++ b/objects/obj_decomp_console/Step_0.gml
@@ -22,13 +22,30 @@ if (!active)
 if (prev_dir_y != dir_y && dir_y != 0)
 {
 	trace($"aa:{array_length(commands_history)} i : {commands_history_index}");
-	if (dir_y == 1 && array_length(commands_history) > 0 && array_length(commands_history) > commands_history_index)
+	
+	if (array_length(commands_history) > 0)
 	{
-		keyboard_string = commands_history[((array_length(commands_history) - 1) - commands_history_index++)];	
-	}
-	else
-	{
-		
+		if (dir_y == 1 && commands_history_index + 1 < array_length(commands_history))
+		{
+			if (commands_history_index == -1)
+			{
+				commands_textbox = keyboard_string;
+			}
+			
+			keyboard_string = commands_history[++commands_history_index];
+		}
+		else if (dir_y == -1)
+		{
+			if (commands_history_index > 0)
+			{
+				keyboard_string = commands_history[--commands_history_index];	
+			}
+			else
+			{
+				commands_history_index = -1;
+				keyboard_string = commands_textbox;
+			}
+		}
 	}
 }
 
@@ -56,7 +73,8 @@ if (keyboard_check_pressed(vk_enter))
 			arg_array = array_create(array_length(temp) - 1);		
 			array_copy(arg_array, 0, temp, 1, arg_count);
 		}
-		commands_history_index = 0;
+		commands_history_index = -1;
+		commands_textbox = "";
 		var commandDef = commands[getCommandDefIndex(command_name)];
 		command_writeline(input_text);
 		trace($"Attempting to execute command: \"{commandDef.displayName}\" with arguments: \"{arg_array}\"");

--- a/scripts/cmd_clear/cmd_clear.gml
+++ b/scripts/cmd_clear/cmd_clear.gml
@@ -1,5 +1,5 @@
 function cmd_clear(_args)
 {
 	obj_decomp_console.history = array_create(0);
-	// TODO: THIS NEEDS TO UPDATE THE VIEW SCROLL 
+	scroll_offset = 0;
 }

--- a/scripts/command_writeline/command_writeline.gml
+++ b/scripts/command_writeline/command_writeline.gml
@@ -1,6 +1,6 @@
 function command_writeline(_text)
 {
 	array_insert(obj_decomp_console.history, 0, _text);
-	if (array_length(obj_decomp_console.history) >= COMMAND_CONSOLE_HISTORY_MAX)
+	if (array_length(obj_decomp_console.history) > COMMAND_CONSOLE_HISTORY_MAX)
 		array_pop(obj_decomp_console.history);
 }

--- a/scripts/command_writeline/command_writeline.gml
+++ b/scripts/command_writeline/command_writeline.gml
@@ -1,6 +1,6 @@
 function command_writeline(_text)
 {
-	array_push(obj_decomp_console.history, _text);
+	array_insert(obj_decomp_console.history, 0, _text);
 	if (array_length(obj_decomp_console.history) >= COMMAND_CONSOLE_HISTORY_MAX)
 		array_pop(obj_decomp_console.history);
 }

--- a/scripts/validCommandName/validCommandName.gml
+++ b/scripts/validCommandName/validCommandName.gml
@@ -7,3 +7,13 @@ function validCommandName(_commandName)
 	}
 	return false;
 }
+
+function getCommandHelpText(_commandName)
+{
+	for (var i = 0; i < array_length(obj_decomp_console.commands); i++)
+	{
+		if (obj_decomp_console.commands[i].displayName == _commandName)
+			return obj_decomp_console.commands[i].about;
+	}
+	return "";
+}


### PR DESCRIPTION
Crappy implementation of the following things for the decomp console:
- Go down through command history with Arrow Down (previously you could only go up), also save state of textbox in case you want to go back to your original command
- Scroll through the console history (for now it uses Arrow Left / Arrow Right to go down / up)
- Shows the help text ahead of time if current command is valid
- Popup with list of partial command matches under the console

There was also a bug where going past COMMAND_CONSOLE_HISTORY_MAX wouldn't update commands / history correctly, I rewrote the push / pop logic to get it fixed.

Branch has two commits from vultu-branch since I saw console-related changes in there.

https://github.com/Vultumast/UndertaleDecomp/assets/19145605/daa23c34-c7c7-42d2-a688-f545201ea527

