### PR TITLE
Fix clipping (?), add command to disable encounters

### DIFF
--- a/NXTALE.yyp
+++ b/NXTALE.yyp
@@ -1689,6 +1689,7 @@
     {"id":{"name":"obj_cherrypetal","path":"objects/obj_cherrypetal/obj_cherrypetal.yy",},},
     {"id":{"name":"obj_playmovement","path":"objects/obj_playmovement/obj_playmovement.yy",},},
     {"id":{"name":"obj_textdrawtest","path":"objects/obj_textdrawtest/obj_textdrawtest.yy",},},
+    {"id":{"name":"cmd_random_encounters","path":"scripts/cmd_random_encounters/cmd_random_encounters.yy",},},
     {"id":{"name":"obj_songwriter","path":"objects/obj_songwriter/obj_songwriter.yy",},},
     {"id":{"name":"obj_mettaton_flightdress","path":"objects/obj_mettaton_flightdress/obj_mettaton_flightdress.yy",},},
     {"id":{"name":"obj_mettaton_dress1","path":"objects/obj_mettaton_dress1/obj_mettaton_dress1.yy",},},

--- a/objects/obj_decomp_console/Create_0.gml
+++ b/objects/obj_decomp_console/Create_0.gml
@@ -25,6 +25,8 @@ mouse_click_y = 0;
 show_collision = false;
 show_position = false;
 
+random_encounters = true;
+
 #macro COMMAND_CONSOLE_HISTORY_MAX 64
 #macro SCROLL_MIN_ENTRIES_SHOWN 6
 function activate() 

--- a/objects/obj_decomp_console/Other_10.gml
+++ b/objects/obj_decomp_console/Other_10.gml
@@ -31,3 +31,5 @@ command_register("battle_start", "Starts a Battle depending on the set battlegro
 command_register("show_solid", "Toggles the solid overlay", [ ]);
 command_register("pos_show", "Toggles the position overlay", [ ]);
 command_register("pos_set", "Sets the position of the player", [ "x", "y" ]);
+
+command_register("random_encounters", "Toggles random monster encounters", [ "value" ]);

--- a/objects/obj_mainchara/Collision_obj_solidparent.gml
+++ b/objects/obj_mainchara/Collision_obj_solidparent.gml
@@ -1,3 +1,5 @@
+#macro colliders_to_check [obj_solidparent, obj_solidnpcparent, obj_sdl, obj_sdr, obj_sul, obj_sur]
+
 if (global.phasing == 0 && other.phase == 0)
 {
     x = xprevious
@@ -6,14 +8,14 @@ if (global.phasing == 0 && other.phase == 0)
     {
         if obj_time.up
         {
-            if (collision_rectangle((x + 2), (y + 15), (x + 18), (y + 19), obj_solidparent, false, true) > 0)
+            if (collision_rectangle((x + 2), (y + 15), (x + 18), (y + 19), colliders_to_check, false, true) > 0)
             {
-                if (obj_time.left && collision_line((bbox_left - 3), bbox_top, bbox_left, bbox_top, obj_solidparent, false, true) < 0)
+                if (obj_time.left && collision_line((bbox_left - 3), bbox_top, bbox_left, bbox_top, colliders_to_check, false, true) < 0)
                 {
                     x -= 3
                     global.facing = Direction.Left
                 }
-                if (obj_time.right && collision_line((bbox_right + 3), bbox_top, bbox_right, bbox_top, obj_solidparent, false, true) < 0)
+                if (obj_time.right && collision_line((bbox_right + 3), bbox_top, bbox_right, bbox_top, colliders_to_check, false, true) < 0)
                 {
                     x += 3
                     global.facing = Direction.Right
@@ -27,14 +29,14 @@ if (global.phasing == 0 && other.phase == 0)
         }
         if obj_time.down
         {
-            if (collision_rectangle((x + 2), (y + 30), (x + 18), (y + 33), obj_solidparent, false, true) > 0)
+            if (collision_rectangle((x + 2), (y + 30), (x + 18), (y + 33), colliders_to_check, false, true) > 0)
             {
-                if (obj_time.left && collision_line((bbox_left - 3), bbox_bottom, bbox_left, bbox_bottom, obj_solidparent, false, true) < 0)
+                if (obj_time.left && collision_line((bbox_left - 3), bbox_bottom, bbox_left, bbox_bottom, colliders_to_check, false, true) < 0)
                 {
                     x -= 3
                     global.facing = Direction.Left
                 }
-                if (obj_time.right && collision_line((bbox_right + 3), bbox_bottom, bbox_right, bbox_bottom, obj_solidparent, false, true) < 0)
+                if (obj_time.right && collision_line((bbox_right + 3), bbox_bottom, bbox_right, bbox_bottom, colliders_to_check, false, true) < 0)
                 {
                     x += 3
                     global.facing = Direction.Right

--- a/objects/obj_mainchara/Step_2.gml
+++ b/objects/obj_mainchara/Step_2.gml
@@ -44,7 +44,7 @@ if (moving == false)
 }
 if (global.interact == 0)
 {
-    if (moving == true)
+    if (moving == true && obj_decomp_console.random_encounters)
         global.encounter += 1
 }
 if (cutscene == false)

--- a/scripts/cmd_random_encounters/cmd_random_encounters.gml
+++ b/scripts/cmd_random_encounters/cmd_random_encounters.gml
@@ -1,0 +1,7 @@
+function cmd_random_encounters(_args)
+{	
+	obj_decomp_console.random_encounters = !obj_decomp_console.random_encounters;
+	
+	var enabled = obj_decomp_console.random_encounters;
+	command_writeline($"Random encounters are now {enabled ? "on" : "off"}.");
+}

--- a/scripts/cmd_random_encounters/cmd_random_encounters.yy
+++ b/scripts/cmd_random_encounters/cmd_random_encounters.yy
@@ -1,0 +1,11 @@
+{
+  "resourceType": "GMScript",
+  "resourceVersion": "1.0",
+  "name": "cmd_random_encounters",
+  "isCompatibility": false,
+  "isDnD": false,
+  "parent": {
+    "name": "Commands",
+    "path": "folders/Scripts/Decomp/Console/Commands.yy",
+  },
+}


### PR DESCRIPTION
Seems to fix #6 I guess, although I'm sure collisions are still pretty off from what they should be.

Maybe the collision scripts run in a different order in GM2 compared to original, and this causes an issue? Dunno. Debug prints say obj_solidparent fires after obj_sdl, which probably doesn't work too well when updating the positions.

Also added a script to toggle encounters since they were getting in the way.

https://github.com/Vultumast/UndertaleDecomp/assets/19145605/7e128977-0d95-4e3c-bf8c-43adbad10798

